### PR TITLE
PROD-3692: Use a patched version of xnat-data-models

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,10 +33,27 @@ jobs:
       - name: Build Devcontainer
         run: docker build -t builder -f .devcontainer/Dockerfile .
 
+      - name: Setup shared local Maven repo
+        run: mkdir m2
+
+      # Apply various patches to `xnat-data-models` and rebuild. The artifact is published to a
+      # local m2 repository which will be shared with the XNAT build. The XNAT build searches
+      # the local m2 repository first as a part of its build, picking up our patched .jar
+
+      - name: xnat-data-models - clone/patch/build
+        run: |
+          git clone --branch 1.8.9.1 https://bitbucket.org/xnatdev/xnat-data-models.git
+          cd xnat-data-models
+          git config user.name "admin-ci"
+          git config user.email "admin@onc.ai"
+          git am ../oncai/patches/xnat-data-models/0001-XNAT-7943-Remove-deprecated-display-doc-fields.patch
+          docker run -t --rm --workdir=/code -v $(pwd):/code -v $(pwd)/../m2:/root/.m2 builder ./gradlew clean jar publishToMavenLocal
+
       - name: Build
         run: |
           echo "org.gradle.jvmargs=-Xmx4096m" > ./gradle.properties
-          docker run -t --rm --workdir=/code -v $(pwd):/code builder ./gradlew build
+          find m2
+          docker run -t --rm --workdir=/code -v $(pwd):/code -v $(pwd)/m2:/root/.m2 builder ./gradlew build
 
       - name: Test
         run: docker run -t --rm --workdir=/code -v $(pwd):/code builder ./gradlew test

--- a/oncai/patches/xnat-data-models/0001-XNAT-7943-Remove-deprecated-display-doc-fields.patch
+++ b/oncai/patches/xnat-data-models/0001-XNAT-7943-Remove-deprecated-display-doc-fields.patch
@@ -1,0 +1,42 @@
+From 6ed86b0ac69668e82cd60439810ca6bc34ffcaaf Mon Sep 17 00:00:00 2001
+From: Timothy Olsen <timolsen@flywheel.io>
+Date: Sat, 2 Dec 2023 00:26:11 +0000
+Subject: [PATCH] XNAT-7943 Remove deprecated display doc fields
+
+Approved-by: James Ransford
+Approved-by: Kate Alpert
+---
+ .../resources/schemas/xnat/display/mrSessionData_display.xml   | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/main/resources/schemas/xnat/display/mrSessionData_display.xml b/src/main/resources/schemas/xnat/display/mrSessionData_display.xml
+index 4e517ff..3a48d63 100644
+--- a/src/main/resources/schemas/xnat/display/mrSessionData_display.xml
++++ b/src/main/resources/schemas/xnat/display/mrSessionData_display.xml
+@@ -325,7 +325,6 @@
+ 		<DisplayFieldRef id="MR_NOTES"/>
+ 		<DisplayFieldRef id="LABEL"/>
+ 		<DisplayFieldRef id="OPERATOR"/>
+-		<DisplayFieldRef id="COHORT" element_name="xnat:subjectData"/>
+ 		<DisplayFieldRef id="SCANNER"/>
+ 		<DisplayFieldRef id="MARKER"/>
+ 		<DisplayFieldRef id="STABILIZATION"/>
+@@ -336,7 +335,6 @@
+ 	<DisplayVersion versionName="detailed_csv" default-order-by="MR_NOTES" brief-description="Mr Session" dark-color="99FF99" light-color="CCFFCC">
+ 		<DisplayFieldRef id="MR_NOTES_CSV"/>
+ 		<DisplayFieldRef id="OPERATOR_CSV"/>
+-		<DisplayFieldRef id="COHORT" element_name="xnat:subjectData"/>
+ 		<DisplayFieldRef id="SCANNER_CSV"/>
+ 		<DisplayFieldRef id="MARKER_CSV"/>
+ 		<DisplayFieldRef id="STABILIZATION_CSV"/>
+@@ -362,7 +360,6 @@
+ 		<DisplayFieldRef id="LAST_MODIFIED"/>
+ 		<DisplayFieldRef id="INVEST"/>
+ 		<DisplayFieldRef id="INSERT_USER"/>
+-		<DisplayFieldRef id="PREARCHIVE"/>
+ 	</DisplayVersion>
+ 	<ViewLink alias="ORDERED_WORKFLOWS">
+ 		<Mapping TableName="ORDERED_WORKFLOWS">
+-- 
+2.34.1
+


### PR DESCRIPTION
Specifically this applies xnat-data-models/6ed86b0 on top of their 1.8.9.1 branch, freeing us from the XNAT exception noise.