### PR TITLE
PROD-3692: Fix .war packaging for cherry-picked datamodels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,12 +55,6 @@ jobs:
           find m2
           docker run -t --rm --workdir=/code -v $(pwd):/code -v $(pwd)/m2:/root/.m2 builder ./gradlew build
 
-      - name: Test
-        run: docker run -t --rm --workdir=/code -v $(pwd):/code builder ./gradlew test
-
-      - name: Package
-        run: docker run -t --rm --workdir=/code -v $(pwd):/code builder ./gradlew war
-
       - name: Rename
         id: rename
         run: |


### PR DESCRIPTION
An `m2` volume mount was provided for the `build` step, however it was omitted for the `package` step, resulting in the upstream version of xnat-data-models being used.

The `build` task performs build/test/package under the same gradle invocation, so removing the `test` and `package` steps.